### PR TITLE
Fix DEB_RE regex for ~YYYYMMDD suffix addition

### DIFF
--- a/himmelblau-auto-build.py
+++ b/himmelblau-auto-build.py
@@ -43,7 +43,7 @@ PACKAGING_DIR = "packaging"
 STABLE_TAG_RE = re.compile(r'^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$')
 NIGHTLY_LABEL_RE = re.compile(r'^(?P<date>\d{4}-\d{2}-\d{2})-[0-9a-f]+$')
 
-DEB_RE = re.compile(r"""(?xi)^.*(?P<ver>\d+\.\d+\.\d+)-(?P<distro>[a-z0-9.]+)_(?P<arch>amd64|arm64)\.deb$""")
+DEB_RE = re.compile(r"""(?xi)^.*(?P<ver>\d+\.\d+\.\d+)-(?P<distro>[a-z0-9.]+)(?:~[0-9a-z]+)?_(?P<arch>amd64|arm64)\.deb$""")
 RPM_RE = re.compile(r"""(?xi).*- (?P<distro>fedora\d+|rawhide|rocky\d+|leap\d(?:\.\d)?|tumbleweed|sle\d+sp\d+|sle\d{2}|amzn\d+) \.rpm$""")
 
 GPG_KEYID = os.environ.get("HBL_GPG_KEYID")


### PR DESCRIPTION
The DEB_RE regex fails due to the date suffix addition and no longer finds the distro, which broke publishing per-distro subdirectories, and instead published into 'unknown' all the deb packages:

https://packages.himmelblau-idm.org/nightly/latest/deb/unknown/

CHange the regex to take into account the possibility of this optional suffix.

Follow-up for 897ef221fd0d0af873252e5539b21b5c9b4d8b2c

I asked copilot to generate a manual test case for the regex just to be sure, and it spat out this, which works with this fix, and fails without:

```
import re
DEB_RE = re.compile(r'(?xi)^.*(?P<ver>\d+\.\d+\.\d+)-(?P<distro>[a-z0-9.]+)(?:~[0-9a-z]+)?_(?P<arch>amd64|arm64)\.deb$')
tests = [
    # (filename, expected_distro, expected_arch)
    ('himmelblau_4.0.0-debian13_amd64.deb',              'debian13',    'amd64'),
    ('himmelblau_4.0.0-debian13~20260329_amd64.deb',     'debian13',    'amd64'),
    ('himmelblau_4.0.0-debian12_amd64.deb',              'debian12',    'amd64'),
    ('himmelblau_4.0.0-debian12~20260402_amd64.deb',     'debian12',    'amd64'),
    ('himmelblau_4.0.0-ubuntu24.04_amd64.deb',           'ubuntu24.04', 'amd64'),
    ('himmelblau_4.0.0-ubuntu24.04~20260329_arm64.deb',  'ubuntu24.04', 'arm64'),
    ('himmelblau_4.0.0-ubuntu22.04_arm64.deb',           'ubuntu22.04', 'arm64'),
    ('nss-himmelblau_4.0.0-debian13~20260329_amd64.deb', 'debian13',    'amd64'),
    ('pam-himmelblau_4.0.0-ubuntu24.04_amd64.deb',       'ubuntu24.04', 'amd64'),
    ('himmelblau-sso_4.0.0-debian12~20260402_arm64.deb', 'debian12',    'arm64'),
]
ok = 0
for fname, exp_distro, exp_arch in tests:
    m = DEB_RE.match(fname)
    distro = m.group('distro') if m else None
    arch = m.group('arch') if m else None
    status = 'PASS' if distro == exp_distro and arch == exp_arch else 'FAIL'
    if status == 'PASS': ok += 1
    print(f'  {status}: {fname} -> distro={distro} arch={arch}')
print(f'\n{ok}/{len(tests)} passed')
```