### PR TITLE
Fix apt repo builder, add tests for repo script, add GitHub Actions action for regression testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: tests
+
+on:
+  push:
+    paths:
+      - himmelblau-auto-build.py
+      - tests/**
+      - .github/workflows/tests.yml
+  pull_request:
+    paths:
+      - himmelblau-auto-build.py
+      - tests/**
+      - .github/workflows/tests.yml
+
+jobs:
+  apt-flat-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            dpkg-dev apt-utils gnupg python3 python3-pytest python3-packaging
+
+      - name: Run tests
+        run: pytest -q tests/

--- a/himmelblau-auto-build.py
+++ b/himmelblau-auto-build.py
@@ -307,6 +307,51 @@ def collect_from_packaging(packaging_dir: Path, built_since: float):
 
 
 # --- Repo metadata ---
+def _scan_packages_index(deb_dir: Path, debs: List[Path],
+                         scan: Optional[str], aptft: Optional[str],
+                         out_path: Path, log) -> bool:
+    # A single corrupt .deb makes a whole-directory dpkg-scanpackages abort,
+    # so fall back to scanning each package and skipping the bad ones.
+    if scan:
+        try:
+            with open(out_path, "wb") as outf:
+                subprocess.run([scan, ".", "/dev/null"], cwd=deb_dir,
+                               check=True, stdout=outf)
+            if out_path.stat().st_size > 0:
+                return True
+        except subprocess.CalledProcessError as e:
+            log(f"WARN: dpkg-scanpackages returned {e.returncode} in "
+                f"{deb_dir}; retrying per-package.")
+
+        # Per-package fallback
+        wrote_any = False
+        with open(out_path, "wb") as outf:
+            for deb in debs:
+                try:
+                    proc = subprocess.run([scan, "./" + deb.name, "/dev/null"],
+                                          cwd=deb_dir, check=True,
+                                          stdout=subprocess.PIPE)
+                except subprocess.CalledProcessError as e:
+                    log(f"WARN: skipping {deb.name} (rc={e.returncode}).")
+                    continue
+                if proc.stdout:
+                    outf.write(proc.stdout)
+                    wrote_any = True
+        return wrote_any and out_path.stat().st_size > 0
+
+    if aptft:
+        try:
+            with open(out_path, "wb") as outf:
+                subprocess.run([aptft, "packages", "."], cwd=deb_dir,
+                               check=True, stdout=outf)
+        except subprocess.CalledProcessError as e:
+            log(f"WARN: apt-ftparchive packages returned {e.returncode} in "
+                f"{deb_dir}.")
+        return out_path.exists() and out_path.stat().st_size > 0
+
+    return False
+
+
 def apt_flat_repo(deb_dir: Path, channel: str):
     deb_dir = Path(deb_dir).resolve()
 
@@ -361,36 +406,26 @@ def apt_flat_repo(deb_dir: Path, channel: str):
     inrelease = deb_dir / "InRelease"
     release_gpg = deb_dir / "Release.gpg"
 
-    # Clean old indices/signatures
-    for p in (packages, packages_gz, inrelease, release_gpg):
-        try:
-            p.unlink()
-        except Exception:
-            pass
-
-    # Create Packages
+    # Build Packages into a temp file and swap it in only if non-empty, so a
+    # failed scan leaves the previous good metadata in place instead of wiping it.
+    debs = sorted(debs)
+    pkg_fd, pkg_tmp_name = tempfile.mkstemp(dir=str(deb_dir),
+                                            prefix=".Packages.")
+    os.close(pkg_fd)
+    pkg_tmp = Path(pkg_tmp_name)
     try:
-        if scan:
-            with open(packages, "wb") as outf:
-                subprocess.run([scan, ".", "/dev/null"], cwd=deb_dir,
-                               check=True, stdout=outf)
+        if _scan_packages_index(deb_dir, debs, scan, aptft, pkg_tmp, log):
+            os.replace(pkg_tmp, packages)
         else:
-            with open(packages, "wb") as outf:
-                if aptft is None:
-                    raise RuntimeError("apt-ftparchive not found")
-                subprocess.run([aptft, "packages", "."], cwd=deb_dir,
-                               check=True, stdout=outf)
-    except subprocess.CalledProcessError as e:
-        # Non-zero exit may be a warning; check if Packages file was created
-        if packages.exists() and packages.stat().st_size > 0:
-            log(f"WARN: {scan or aptft} returned non-zero exit code "
-                f"{e.returncode}, but Packages file was created "
-                f"({packages.stat().st_size} bytes). Continuing.")
-        else:
-            log(f"ERROR: {scan or aptft} failed with exit code {e.returncode} "
-                f"and Packages file is missing or empty. Skipping APT metadata "
-                f"for {deb_dir}.")
+            log(f"ERROR: empty Packages index for {deb_dir}; "
+                f"leaving existing APT metadata untouched.")
             return
+    finally:
+        if pkg_tmp.exists():
+            try:
+                pkg_tmp.unlink()
+            except Exception:
+                pass
 
     # gzip -n -c Packages > Packages.gz
     try:
@@ -403,11 +438,6 @@ def apt_flat_repo(deb_dir: Path, channel: str):
         # Continue without .gz - the uncompressed Packages file is sufficient
 
     # Build Release atomically
-    try:
-        release.unlink()
-    except Exception:
-        pass
-
     archs = set()
     for deb in debs:
         if "_amd64.deb" in deb.name:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Provide the build script as a module fixture (its filename is hyphenated,
+so it cannot be imported normally)."""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "himmelblau-auto-build.py"
+
+
+@pytest.fixture(scope="session")
+def hab():
+    spec = importlib.util.spec_from_file_location("himmelblau_auto_build", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_apt_flat_repo.py
+++ b/tests/test_apt_flat_repo.py
@@ -1,0 +1,78 @@
+"""Regression tests for apt_flat_repo() resilience against corrupt .deb files.
+
+These require dpkg-deb, dpkg-scanpackages (dpkg-dev) and apt-ftparchive
+(apt-utils) on PATH, so they only run on a Debian/Ubuntu host or container.
+Tests are skipped when those tools are unavailable.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not (shutil.which("dpkg-deb") and shutil.which("dpkg-scanpackages")),
+    reason="requires dpkg-deb and dpkg-scanpackages",
+)
+
+
+def _make_deb(dirpath: Path, name: str, version: str = "1.0",
+              arch: str = "amd64") -> Path:
+    root = dirpath / f"build-{name}"
+    (root / "DEBIAN").mkdir(parents=True)
+    (root / "DEBIAN" / "control").write_text(
+        f"Package: {name}\nVersion: {version}\nArchitecture: {arch}\n"
+        f"Maintainer: test <test@example.com>\nDescription: test {name}\n"
+    )
+    out = dirpath / f"{name}_{version}_{arch}.deb"
+    subprocess.run(["dpkg-deb", "--build", "-Znone", str(root), str(out)],
+                   check=True, stdout=subprocess.DEVNULL)
+    shutil.rmtree(root)
+    return out
+
+
+def _corrupt_deb(dirpath: Path, name: str = "bad-pkg") -> Path:
+    bad = dirpath / f"{name}_1.0_amd64.deb"
+    bad.write_bytes(b"!<arch>\nnot a valid deb archive")
+    return bad
+
+
+def test_corrupt_deb_does_not_break_index(hab, tmp_path):
+    _make_deb(tmp_path, "good-one")
+    _make_deb(tmp_path, "good-two")
+    _corrupt_deb(tmp_path)
+
+    hab.apt_flat_repo(tmp_path, "nightly")
+
+    packages = (tmp_path / "Packages").read_text()
+    assert "Package: good-one" in packages
+    assert "Package: good-two" in packages
+    assert "bad-pkg" not in packages
+    assert (tmp_path / "Packages.gz").exists()
+    assert (tmp_path / "Release").stat().st_size > 0
+
+
+def test_existing_metadata_preserved_when_index_would_be_empty(hab, tmp_path):
+    seed = _make_deb(tmp_path, "seed")
+    hab.apt_flat_repo(tmp_path, "nightly")
+    old_packages = (tmp_path / "Packages").read_text()
+    old_release = (tmp_path / "Release").read_text()
+
+    # Drop the only good package and leave a corrupt one: a fresh scan is empty.
+    seed.unlink()
+    _corrupt_deb(tmp_path)
+    hab.apt_flat_repo(tmp_path, "nightly")
+
+    assert (tmp_path / "Packages").read_text() == old_packages
+    assert (tmp_path / "Release").read_text() == old_release
+
+
+def test_clean_directory_indexes_all_packages(hab, tmp_path):
+    _make_deb(tmp_path, "alpha")
+    _make_deb(tmp_path, "beta")
+
+    hab.apt_flat_repo(tmp_path, "nightly")
+
+    packages = (tmp_path / "Packages").read_text()
+    assert "Package: alpha" in packages
+    assert "Package: beta" in packages


### PR DESCRIPTION
Make the himmelblau-auto-build apt repo publisher resilient to corrupt or truncated .deb files. Previously a single bad package caused dpkg-scanpackages to abort the entire index, leaving a 0-byte Packages file, and the error path returned before writing Release while the pre-delete step had already removed the previous good metadata. The result was a [completely broken nightly repository](https://packages.himmelblau-idm.org/nightly/2026-06-10-8f268141e51d/deb/ubuntu24.04/) (404 on Release, empty Packages) that stayed broken until the next fully-clean publish.

The fix scans packages into a temporary file and only swaps it into place when it produced a non-empty index, falling back to a per-package scan that skips individual corrupt .debs. If a fresh scan would be empty, the existing metadata is left untouched instead of being deleted, so a bad build can never take down a previously-working repo.

This PR also adds a pytest regression suite under tests/ covering the corrupt-deb-skipped, existing-metadata-preserved, and clean-directory cases, plus a GitHub Actions workflow that installs the dpkg/apt tooling and runs the tests whenever himmelblau-auto-build.py or the tests change, on pushes and pull requests.