### PR TITLE
Fix RPM routing for aarch64 package publishing

### DIFF
--- a/himmelblau-auto-build.py
+++ b/himmelblau-auto-build.py
@@ -54,7 +54,7 @@ DEB_RE = re.compile(
     r"""(?xi)^.*(?P<ver>\d+\.\d+\.\d+)-(?P<distro>[a-z0-9.]+)(?:~[0-9a-z]+)?_(?P<arch>amd64|arm64)\.deb$"""
 )
 RPM_RE = re.compile(
-    r"""(?xi).*- (?P<distro>fedora\d+|rawhide|rocky\d+|leap\d(?:\.\d)?|tumbleweed|sle\d+sp\d+|sle\d{2}|amzn\d+) \.rpm$"""
+    r"""(?xi).*-(?P<distro>fedora\d+|rawhide|rocky\d+|leap\d(?:\.\d)?|tumbleweed|sle\d+sp\d+|sle\d{2}|amzn\d+)\.rpm$"""
 )
 
 GPG_KEYID = os.environ.get("HBL_GPG_KEYID")

--- a/test_himmelblau_auto_build.py
+++ b/test_himmelblau_auto_build.py
@@ -1,0 +1,54 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("himmelblau-auto-build.py")
+SPEC = importlib.util.spec_from_file_location("himmelblau_auto_build", MODULE_PATH)
+auto_build = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(auto_build)
+
+
+class ArtifactParsingTests(unittest.TestCase):
+    def test_parse_rpm_artifact_detects_distro_for_x86_64(self):
+        kind, distro = auto_build.parse_artifact(
+            Path("himmelblau-3.2.0-1.x86_64-fedora44.rpm")
+        )
+
+        self.assertEqual(kind, "rpm")
+        self.assertEqual(distro, "fedora44")
+
+    def test_parse_rpm_artifact_detects_distro_for_aarch64(self):
+        kind, distro = auto_build.parse_artifact(
+            Path("himmelblau-3.2.0-1.aarch64-rocky10.rpm")
+        )
+
+        self.assertEqual(kind, "rpm")
+        self.assertEqual(distro, "rocky10")
+
+    def test_collect_from_packaging_buckets_aarch64_rpms_by_distro(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            packaging = Path(tmp)
+            rpm = packaging / "himmelblau-3.2.0-1.aarch64-tumbleweed.rpm"
+            rpm.touch()
+
+            _, rpm_map, _ = auto_build.collect_from_packaging(
+                packaging, built_since=0
+            )
+
+        self.assertEqual(list(rpm_map), ["tumbleweed"])
+        self.assertEqual([p.name for p in rpm_map["tumbleweed"]], [rpm.name])
+
+    def test_published_has_pkgs_detects_arm64_rpm_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rpm_dir = base / "rpm" / "fedora44"
+            rpm_dir.mkdir(parents=True)
+            (rpm_dir / "himmelblau-3.2.0-1.aarch64-fedora44.rpm").touch()
+
+            self.assertTrue(auto_build.published_has_pkgs(base, "arm64-fedora44"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix RPM artifact distro detection so generated files like `*.aarch64-fedora44.rpm` are published under the correct distro repository instead of `unknown`.
- Add focused unit tests for x86_64 and aarch64 RPM parsing and published artifact detection.

## Validation
- `python3 -m unittest -v test_himmelblau_auto_build.py`

Addresses the RPM publication gap noted in himmelblau-idm/himmelblau#1195.